### PR TITLE
Fix none result as failed

### DIFF
--- a/changelog/3.fixed
+++ b/changelog/3.fixed
@@ -1,0 +1,1 @@
+Fix textfile output to view None result as success

--- a/src/saltext/prometheus/returners/prometheus_textfile.py
+++ b/src/saltext/prometheus/returners/prometheus_textfile.py
@@ -255,10 +255,10 @@ def returner(ret):
     for data in ret.get("return", {}).values():
         total += 1
         duration += data.get("duration", 0)
-        if data["result"]:
-            success += 1
-        else:
+        if data["result"] is False:
             failure += 1
+        else:
+            success += 1
         if data.get("changes"):
             changed += 1
 
@@ -331,7 +331,7 @@ def returner(ret):
 
     if opts["show_failed_states"]:
         for state_id, state_return in ret["return"].items():
-            if not state_return["result"]:
+            if state_return["result"] is False:
                 key = (
                     'salt_failed{state_id="'
                     + state_id.split("_|-")[1]

--- a/tests/unit/returners/test_prometheus_textfile_return.py
+++ b/tests/unit/returners/test_prometheus_textfile_return.py
@@ -48,7 +48,7 @@ def job_ret():
                     "stdout": "applyme",
                     "stderr": "",
                 },
-                "result": True,
+                "result": None,
                 "comment": 'Command "echo applyme" run',
                 "__sls__": "applyme",
                 "__run_num__": 1,


### PR DESCRIPTION
### What does this PR do?
Salt only counts states with a `False` result as failed. `None` result should not increment the failure count.

### What issues does this PR fix or reference?
Fixes: #3 

### Previous Behavior
`None` return counts as failed.

### New Behavior
`None` return is a success

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
